### PR TITLE
Let browser terminals paste clipboard images into tmux sessions

### DIFF
--- a/pkg/peer/pty_manager.go
+++ b/pkg/peer/pty_manager.go
@@ -1,7 +1,6 @@
 package peer
 
 import (
-
 	"net/url"
 	"sync"
 
@@ -107,7 +106,9 @@ func (pm *PTYManager) Open(req PTYOpenPayload) {
 					return
 				}
 			case websocket.TextMessage:
-				// Could be resize, but resize comes over control channel
+				if err := tmux.HandlePTYControlMessage(ptySess, data); err != nil {
+					log.WithError(err).Debug("control message failed")
+				}
 			}
 		}
 	}()

--- a/pkg/tmux/paste_image.go
+++ b/pkg/tmux/paste_image.go
@@ -1,0 +1,131 @@
+package tmux
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const maxPastedImageBytes = 10 << 20
+
+type PTYControlMessage struct {
+	Type     string `json:"type"`
+	Cols     uint16 `json:"cols,omitempty"`
+	Rows     uint16 `json:"rows,omitempty"`
+	Data     string `json:"data,omitempty"`
+	Mime     string `json:"mime,omitempty"`
+	Filename string `json:"filename,omitempty"`
+}
+
+// HandlePTYControlMessage applies a websocket control message to a PTY-backed tmux session.
+func HandlePTYControlMessage(ptySess *PTYSession, raw []byte) error {
+	var msg PTYControlMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		return err
+	}
+
+	switch msg.Type {
+	case "resize":
+		if msg.Cols == 0 || msg.Rows == 0 {
+			return nil
+		}
+		return ptySess.Resize(msg.Cols, msg.Rows)
+	case "paste-image":
+		path, err := StorePastedImage(msg.Data, msg.Mime, msg.Filename)
+		if err != nil {
+			return err
+		}
+		_, err = ptySess.Write([]byte(path))
+		return err
+	default:
+		return fmt.Errorf("unknown PTY control message type %q", msg.Type)
+	}
+}
+
+func StorePastedImage(data, mimeType, filename string) (string, error) {
+	if strings.TrimSpace(data) == "" {
+		return "", fmt.Errorf("missing pasted image data")
+	}
+	if mimeType != "" && !strings.HasPrefix(strings.ToLower(mimeType), "image/") {
+		return "", fmt.Errorf("unsupported pasted image MIME type %q", mimeType)
+	}
+
+	decodedLen := base64.StdEncoding.DecodedLen(len(data))
+	if decodedLen <= 0 {
+		return "", fmt.Errorf("invalid pasted image payload")
+	}
+	if decodedLen > maxPastedImageBytes {
+		return "", fmt.Errorf("pasted image exceeds %d byte limit", maxPastedImageBytes)
+	}
+
+	imageBytes, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return "", fmt.Errorf("decode pasted image: %w", err)
+	}
+	if len(imageBytes) == 0 {
+		return "", fmt.Errorf("empty pasted image payload")
+	}
+	if len(imageBytes) > maxPastedImageBytes {
+		return "", fmt.Errorf("pasted image exceeds %d byte limit", maxPastedImageBytes)
+	}
+
+	dir := filepath.Join(os.TempDir(), "guppi-paste")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create paste directory: %w", err)
+	}
+
+	path := filepath.Join(dir, pastedImageName(mimeType, filename))
+	if err := os.WriteFile(path, imageBytes, 0o600); err != nil {
+		return "", fmt.Errorf("write pasted image: %w", err)
+	}
+
+	return path, nil
+}
+
+func pastedImageName(mimeType, filename string) string {
+	stamp := time.Now().UTC().Format("20060102-150405")
+	return fmt.Sprintf("pasted-%s-%s%s", stamp, randomHex(4), pastedImageExt(mimeType, filename))
+}
+
+func pastedImageExt(mimeType, filename string) string {
+	switch strings.ToLower(mimeType) {
+	case "image/png":
+		return ".png"
+	case "image/jpeg", "image/jpg":
+		return ".jpg"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	case "image/bmp":
+		return ".bmp"
+	case "image/heic":
+		return ".heic"
+	case "image/heif":
+		return ".heif"
+	}
+
+	switch ext := strings.ToLower(filepath.Ext(filename)); ext {
+	case ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".heic", ".heif":
+		if ext == ".jpeg" {
+			return ".jpg"
+		}
+		return ext
+	}
+
+	return ".png"
+}
+
+func randomHex(n int) string {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(buf)
+}

--- a/pkg/tmux/paste_image_test.go
+++ b/pkg/tmux/paste_image_test.go
@@ -1,0 +1,50 @@
+package tmux
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStorePastedImage(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	path, err := StorePastedImage(base64.StdEncoding.EncodeToString([]byte("png-bytes")), "image/png", "clipboard.png")
+	if err != nil {
+		t.Fatalf("StorePastedImage returned error: %v", err)
+	}
+	if filepath.Ext(path) != ".png" {
+		t.Fatalf("expected .png extension, got %q", filepath.Ext(path))
+	}
+	if !strings.Contains(path, filepath.Join("guppi-paste", "pasted-")) {
+		t.Fatalf("expected guppi-paste temp path, got %q", path)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if string(got) != "png-bytes" {
+		t.Fatalf("expected written bytes to round-trip, got %q", string(got))
+	}
+}
+
+func TestStorePastedImageRejectsInvalidMime(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	_, err := StorePastedImage(base64.StdEncoding.EncodeToString([]byte("not-an-image")), "text/plain", "notes.txt")
+	if err == nil {
+		t.Fatal("expected unsupported MIME type error")
+	}
+}
+
+func TestStorePastedImageRejectsInvalidBase64(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	_, err := StorePastedImage("%%%not-base64%%%", "image/png", "broken.png")
+	if err == nil {
+		t.Fatal("expected invalid base64 error")
+	}
+}

--- a/pkg/ws/pty_terminal.go
+++ b/pkg/ws/pty_terminal.go
@@ -1,7 +1,6 @@
 package ws
 
 import (
-	"encoding/json"
 	"net/http"
 	"strconv"
 
@@ -24,13 +23,6 @@ func NewPTYTerminalHandler(tmuxPath string, activityTracker *activity.Tracker) *
 		tmuxPath:        tmuxPath,
 		activityTracker: activityTracker,
 	}
-}
-
-// resizeMsg is the JSON control message for resize events
-type resizeMsg struct {
-	Type string `json:"type"`
-	Cols uint16 `json:"cols"`
-	Rows uint16 `json:"rows"`
 }
 
 // HandleSession handles a WebSocket connection for an entire tmux session via PTY.
@@ -103,15 +95,8 @@ func (h *PTYTerminalHandler) HandleSession(w http.ResponseWriter, r *http.Reques
 
 		switch msgType {
 		case websocket.TextMessage:
-			var msg resizeMsg
-			if err := json.Unmarshal(message, &msg); err != nil {
-				log.WithError(err).Debug("invalid control message")
-				continue
-			}
-			if msg.Type == "resize" && msg.Cols > 0 && msg.Rows > 0 {
-				if err := ptySess.Resize(msg.Cols, msg.Rows); err != nil {
-					log.WithError(err).Debug("resize failed")
-				}
+			if err := tmux.HandlePTYControlMessage(ptySess, message); err != nil {
+				log.WithError(err).Debug("control message failed")
 			}
 
 		case websocket.BinaryMessage:

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -85,11 +85,39 @@ const clipboardProvider: IClipboardProvider = {
   },
 }
 
+const MAX_PASTED_IMAGE_BYTES = 10 * 1024 * 1024
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  const chunkSize = 0x8000
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize)
+    binary += String.fromCharCode(...chunk)
+  }
+  return btoa(binary)
+}
+
+async function sendPastedImage(ws: WebSocket, file: File, fallbackType: string): Promise<void> {
+  if (file.size > MAX_PASTED_IMAGE_BYTES) {
+    console.warn(`Pasted image exceeds ${MAX_PASTED_IMAGE_BYTES} byte limit`)
+    return
+  }
+
+  const buffer = await file.arrayBuffer()
+  ws.send(JSON.stringify({
+    type: 'paste-image',
+    data: bytesToBase64(new Uint8Array(buffer)),
+    mime: file.type || fallbackType,
+    filename: file.name,
+  }))
+}
+
 export function useTerminal(sessionName: string, hostId?: string) {
   const termRef = useRef<Terminal | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
   const wsRef = useRef<WebSocket | null>(null)
   const containerRef = useRef<HTMLElement | null>(null)
+  const listenerCleanupRef = useRef<(() => void) | null>(null)
   const reconnectTimer = useRef<number | undefined>(undefined)
   const activeConnId = useRef(0)
   const [termConnected, setTermConnected] = useState(false)
@@ -118,6 +146,8 @@ export function useTerminal(sessionName: string, hostId?: string) {
     }
     cleanupWs()
     if (termRef.current) {
+      listenerCleanupRef.current?.()
+      listenerCleanupRef.current = null
       termRef.current.dispose()
     }
 
@@ -149,6 +179,7 @@ export function useTerminal(sessionName: string, hostId?: string) {
     ;(window as any).__term = term
 
     term.open(container)
+    const helperTextarea = container.querySelector('textarea.xterm-helper-textarea') as HTMLTextAreaElement | null
 
     // Request clipboard-write permission early so OSC 52 writes may work directly
     requestClipboardPermission()
@@ -200,13 +231,40 @@ export function useTerminal(sessionName: string, hostId?: string) {
 
     // Flush deferred clipboard writes on mouse interaction (capture phase
     // to intercept before xterm.js can stopPropagation)
-    container.addEventListener('mousedown', flushPendingClipboard, true)
-    container.addEventListener('keydown', flushPendingClipboard, true)
+    const onMouseDown = () => flushPendingClipboard()
+    const onKeyDown = () => flushPendingClipboard()
+    const onPaste = (e: ClipboardEvent) => {
+      const items = Array.from(e.clipboardData?.items ?? [])
+      const imageItem = items.find(item => item.type.startsWith('image/'))
+      if (!imageItem) return
+
+      const file = imageItem.getAsFile()
+      const currentWs = wsRef.current
+      if (!file || !currentWs || currentWs.readyState !== WebSocket.OPEN) return
+
+      e.preventDefault()
+
+      sendPastedImage(currentWs, file, imageItem.type)
+        .catch((err) => {
+          console.error('Failed to read pasted image:', err)
+        })
+    }
+    const onContextMenu = (e: MouseEvent) => {
+      e.preventDefault()
+    }
+
+    container.addEventListener('mousedown', onMouseDown, true)
+    container.addEventListener('keydown', onKeyDown, true)
+    helperTextarea?.addEventListener('paste', onPaste)
 
     // Suppress browser's native context menu so right-click passes through to tmux
-    container.addEventListener('contextmenu', (e) => {
-      e.preventDefault()
-    })
+    container.addEventListener('contextmenu', onContextMenu)
+    listenerCleanupRef.current = () => {
+      container.removeEventListener('mousedown', onMouseDown, true)
+      container.removeEventListener('keydown', onKeyDown, true)
+      helperTextarea?.removeEventListener('paste', onPaste)
+      container.removeEventListener('contextmenu', onContextMenu)
+    }
 
     // Fit terminal to container — retry a few times to handle layout settling
     const doFit = () => {
@@ -307,6 +365,8 @@ export function useTerminal(sessionName: string, hostId?: string) {
     }
     cleanupWs()
     if (termRef.current) {
+      listenerCleanupRef.current?.()
+      listenerCleanupRef.current = null
       termRef.current.dispose()
       termRef.current = null
     }


### PR DESCRIPTION
The web terminal now intercepts pasted clipboard images, sends them over the existing PTY websocket control channel, stores them on the owning host, and inserts the resulting file path into the session input. 

This keeps local and remote session behavior aligned without adding a separate upload API.

Confidence: high
Scope-risk: moderate
Reversibility: clean

Tested: `go test ./pkg/tmux ./pkg/peer ./pkg/ws`
Tested: `npm run build`
