### PR TITLE
fix: mobile responsive layout for web dashboard

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="apple-mobile-web-app-title" content="guppi" />

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "guppi-web",
-  "version": "0.1.2-beta.2",
+  "version": "0.1.3-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "guppi-web",
-      "version": "0.1.2-beta.2",
+      "version": "0.1.3-beta.2",
       "dependencies": {
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.10.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,6 +24,17 @@ import { applyTheme } from './theme'
 
 type View = 'overview' | 'session' | 'settings' | 'setup'
 
+function useIsMobile(breakpoint = 768) {
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth < breakpoint)
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${breakpoint - 1}px)`)
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [breakpoint])
+  return isMobile
+}
+
 function getViewFromPath(): { view: View; sessionKey: string | null } {
   if (window.location.pathname === '/settings') {
     return { view: 'settings', sessionKey: null }
@@ -64,6 +75,8 @@ function AppInner({ onLogout }: { onLogout?: () => void }) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
     try { return localStorage.getItem('guppi:sidebar-collapsed') === 'true' } catch { return false }
   })
+  const isMobile = useIsMobile()
+  const [sidebarOpen, setSidebarOpen] = useState(false)
   const [terminalFullscreen, setTerminalFullscreen] = useState(false)
   const [helpOpen, setHelpOpen] = useState(false)
   const pendingSessionRef = useRef<string | null>(null)
@@ -116,6 +129,11 @@ function AppInner({ onLogout }: { onLogout?: () => void }) {
   useEffect(() => {
     localStorage.setItem('guppi:sidebar-collapsed', String(sidebarCollapsed))
   }, [sidebarCollapsed])
+
+  // Auto-close mobile sidebar overlay when session changes
+  useEffect(() => {
+    if (isMobile) setSidebarOpen(false)
+  }, [selectedSession, isMobile])
 
   // Sync URL -> state on popstate (back/forward)
   useEffect(() => {
@@ -412,6 +430,9 @@ function AppInner({ onLogout }: { onLogout?: () => void }) {
           currentView={currentView}
           sidebarCollapsed={sidebarCollapsed}
           onToggleCollapse={() => setSidebarCollapsed(c => !c)}
+          onToggleSidebar={() => isMobile ? setSidebarOpen(o => !o) : setSidebarCollapsed(c => !c)}
+          isMobile={isMobile}
+          sidebarOpen={sidebarOpen}
           onOverview={() => navigateTo(null)}
           onSettings={navigateToSettings}
           onNewSession={openNewSessionModal}
@@ -424,7 +445,8 @@ function AppInner({ onLogout }: { onLogout?: () => void }) {
       )}
       {/* Middle: Sidebar + Content */}
       <div className="flex-1 flex overflow-hidden">
-        {!terminalFullscreen && (
+        {/* Desktop: persistent sidebar */}
+        {!isMobile && !terminalFullscreen && (
           <Sidebar
             sessions={sessions}
             selectedSession={selectedSession}
@@ -438,6 +460,26 @@ function AppInner({ onLogout }: { onLogout?: () => void }) {
             getSessionEvents={getSessionEvents}
             sessionNeedsAttention={sessionNeedsAttention}
             getSessionActivity={getSessionActivity}
+          />
+        )}
+        {/* Mobile: sidebar overlay */}
+        {isMobile && !terminalFullscreen && (
+          <Sidebar
+            sessions={sessions}
+            selectedSession={selectedSession}
+            collapsed={false}
+            collapseMode="small"
+            hasMultipleHosts={hasMultipleHosts}
+            onSessionSelect={handleSessionSelect}
+            onSessionRenamed={(oldKey, newKey) => {
+              if (selectedSession === oldKey) navigateTo(newKey)
+            }}
+            getSessionEvents={getSessionEvents}
+            sessionNeedsAttention={sessionNeedsAttention}
+            getSessionActivity={getSessionActivity}
+            isMobile={true}
+            open={sidebarOpen}
+            onClose={() => setSidebarOpen(false)}
           />
         )}
         <div className="flex-1 flex flex-col overflow-hidden">

--- a/web/src/components/Overview.tsx
+++ b/web/src/components/Overview.tsx
@@ -115,7 +115,7 @@ function UsageBar({ percent, color, label }: { percent: number; color: string; l
 
 function StatCard({ label, value, sub, color }: { label: string; value: string | number; sub?: string; color?: string }) {
   return (
-    <div className="bg-card border border-border rounded-lg p-4 flex-1 min-w-[120px]">
+    <div className="bg-card border border-border rounded-lg p-4 flex-1 min-w-[90px]">
       <div className="text-2xl font-bold" style={{ color: color || 'var(--color-foreground)' }}>{value}</div>
       <div className="text-xs text-muted-foreground mt-1">{label}</div>
       {sub && <div className="text-[11px] text-muted-foreground/60 mt-0.5">{sub}</div>}
@@ -234,7 +234,7 @@ function HostStatsSection({ host, totalPanes }: { host: Host; totalPanes: number
         <span className={`w-1.5 h-1.5 rounded-full ${host.online ? 'bg-success' : 'bg-muted-foreground'}`} />
         {host.name}
       </h3>
-      <div className="grid grid-cols-[repeat(auto-fit,minmax(340px,1fr))] gap-3">
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(min(340px,100%),1fr))] gap-3">
         {processes.length > 0 && (
           <div>
             <div className="text-xs text-muted-foreground mb-1.5">Processes</div>
@@ -388,7 +388,7 @@ export function Overview({
               {groupLabel}
               <span className="text-muted-foreground/60 font-normal text-xs">({groupSessions.length})</span>
             </h3>
-            <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-3">
+            <div className="grid grid-cols-[repeat(auto-fill,minmax(min(320px,100%),1fr))] gap-3">
               {groupSessions.map((session) => {
                 const sk = sessionKey(session)
                 const events = getSessionEvents(sk)
@@ -490,7 +490,7 @@ export function Overview({
           return <HostStatsSection key={host.id} host={host} totalPanes={paneCount} />
         })
       ) : (
-        <div className="grid grid-cols-[repeat(auto-fit,minmax(340px,1fr))] gap-3">
+        <div className="grid grid-cols-[repeat(auto-fit,minmax(min(340px,100%),1fr))] gap-3">
           {stats && stats.processes && stats.processes.length > 0 && (
             <div>
               <h3 className="text-foreground text-sm font-semibold mb-2.5">Processes</h3>

--- a/web/src/components/Settings.tsx
+++ b/web/src/components/Settings.tsx
@@ -67,7 +67,7 @@ function Divider() {
 
 function Row({ label, description, children }: { label: string; description?: string; children: React.ReactNode }) {
   return (
-    <div className="flex items-center justify-between gap-4 py-1.5">
+    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 py-1.5">
       <div className="flex-1">
         <div className="text-sm text-foreground">{label}</div>
         {description && <div className="text-xs text-muted-foreground mt-0.5">{description}</div>}
@@ -84,7 +84,7 @@ function SelectInput({ value, onChange, options }: { value: string; onChange: (v
     <select
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      className="bg-input border border-border rounded px-2 py-1 text-sm text-foreground outline-none focus:border-primary min-w-[160px]"
+      className="bg-input border border-border rounded px-2 py-1 text-sm text-foreground outline-none focus:border-primary min-w-0 sm:min-w-[160px]"
     >
       {options.map(o => (
         <option key={o.value} value={o.value}>{o.label}</option>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -17,6 +17,9 @@ interface SidebarProps {
   getSessionEvents: (session: string) => ToolEvent[]
   sessionNeedsAttention: (session: string) => boolean
   getSessionActivity: (session: string) => ActivitySnapshot | undefined
+  isMobile?: boolean
+  open?: boolean
+  onClose?: () => void
 }
 
 const shellCommands = new Set(['bash', 'zsh', 'fish', 'sh', 'dash', 'ksh', 'csh', 'tcsh', 'tmux', 'login'])
@@ -101,6 +104,9 @@ export function Sidebar({
   getSessionEvents,
   sessionNeedsAttention,
   getSessionActivity,
+  isMobile,
+  open,
+  onClose,
 }: SidebarProps) {
   const { prefs } = usePreferences()
   const [hiddenSet, setHiddenSet] = useState<Set<string>>(() => getHiddenSessions())
@@ -250,16 +256,13 @@ export function Sidebar({
     )
   }
 
-  const isHidden = collapsed && collapseMode === 'hidden'
+  const isHidden = !isMobile && collapsed && collapseMode === 'hidden'
 
-  return (
-    <aside className={cn(
-      'flex flex-col h-full bg-sidebar transition-all duration-300 font-mono text-sm font-bold',
-      collapsed
-        ? collapseMode === 'hidden' ? 'w-0 overflow-hidden' : 'w-16'
-        : 'w-56',
-      !isHidden && 'border-r border-sidebar-border',
-    )}>
+  // Mobile overlay: not open = don't render
+  if (isMobile && !open) return null
+
+  const sidebarContent = (
+    <>
       {/* Session list */}
       <nav className="flex-1 overflow-y-auto p-2">
         <ul className="space-y-1">
@@ -341,6 +344,39 @@ export function Sidebar({
           </div>
         </div>
       )}
+    </>
+  )
+
+  // Mobile overlay rendering
+  if (isMobile) {
+    return (
+      <>
+        {/* Backdrop */}
+        <div
+          className="fixed inset-0 z-40 bg-black/50"
+          onClick={onClose}
+        />
+        <aside className={cn(
+          'fixed inset-y-0 left-0 z-50 w-64 flex flex-col bg-sidebar font-mono text-sm font-bold',
+          'border-r border-sidebar-border',
+          'animate-[slideInFromLeft_0.2s_ease-out]',
+        )}>
+          {sidebarContent}
+        </aside>
+      </>
+    )
+  }
+
+  // Desktop rendering (original behavior)
+  return (
+    <aside className={cn(
+      'flex flex-col h-full bg-sidebar transition-all duration-300 font-mono text-sm font-bold',
+      collapsed
+        ? collapseMode === 'hidden' ? 'w-0 overflow-hidden' : 'w-16'
+        : 'w-56',
+      !isHidden && 'border-r border-sidebar-border',
+    )}>
+      {sidebarContent}
     </aside>
   )
 }

--- a/web/src/components/StatusBar.tsx
+++ b/web/src/components/StatusBar.tsx
@@ -58,12 +58,12 @@ export function StatusBar({ sessionCount, connected, activeSession, waitingCount
 
   return (
     <footer className="flex items-center justify-between px-4 py-1 border-t border-border bg-card text-xs text-muted-foreground font-mono font-bold">
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-4 overflow-x-auto">
         {peersConfigured > 0 && (
-          <span>PEERS: <span className={peersConnected === peersConfigured ? 'text-foreground' : 'text-warning'}>{peersConnected}/{peersConfigured}</span></span>
+          <span className="hidden md:inline">PEERS: <span className={peersConnected === peersConfigured ? 'text-foreground' : 'text-warning'}>{peersConnected}/{peersConfigured}</span></span>
         )}
         {hosts.length > 1 && (
-          <span>HOSTS: <span className="text-foreground">{hostCount}</span></span>
+          <span className="hidden md:inline">HOSTS: <span className="text-foreground">{hostCount}</span></span>
         )}
         <span>SESSIONS: <span className="text-foreground">{sessionCount}</span></span>
         <span>AGENTS: <span className={totalAgents > 0 ? 'text-foreground' : ''}>{totalAgents}</span></span>
@@ -80,15 +80,15 @@ export function StatusBar({ sessionCount, connected, activeSession, waitingCount
           <span className="text-warning">WAITING: {waitingCount}</span>
         )}
       </div>
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-4 overflow-x-auto">
         {stats.cpu_percent !== undefined && (
-          <span>CPU: <span className="text-foreground">{stats.cpu_percent}%</span></span>
+          <span className="hidden md:inline">CPU: <span className="text-foreground">{stats.cpu_percent}%</span></span>
         )}
         {stats.memory && (
-          <span>MEM: <span className="text-foreground">{stats.memory.percent}%</span></span>
+          <span className="hidden md:inline">MEM: <span className="text-foreground">{stats.memory.percent}%</span></span>
         )}
         {pushState !== 'unsupported' && (
-          <span className="flex items-center gap-1">
+          <span className="hidden md:flex items-center gap-1">
             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" /><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
             </svg>
@@ -106,7 +106,7 @@ export function StatusBar({ sessionCount, connected, activeSession, waitingCount
           </span>
         </span>
         {version && (
-          <span className="flex items-center gap-1">
+          <span className="hidden md:flex items-center gap-1">
             {updateAvailable ? (
               <button
                 onClick={() => window.location.reload()}

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -8,6 +8,9 @@ interface TopBarProps {
   currentView: string
   sidebarCollapsed: boolean
   onToggleCollapse: () => void
+  onToggleSidebar: () => void
+  isMobile?: boolean
+  sidebarOpen?: boolean
   onOverview: () => void
   onSettings: () => void
   onNewSession?: () => void
@@ -27,6 +30,9 @@ export function TopBar({
   currentView,
   sidebarCollapsed,
   onToggleCollapse,
+  onToggleSidebar,
+  isMobile,
+  sidebarOpen,
   onOverview,
   onSettings,
   onNewSession,
@@ -84,12 +90,14 @@ export function TopBar({
             </svg>
           </button>
           <button
-            onClick={onToggleCollapse}
-            title={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            onClick={onToggleSidebar}
+            title={isMobile ? (sidebarOpen ? 'Close sidebar' : 'Open sidebar') : sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
             className="p-1.5 rounded hover:bg-accent text-foreground transition-colors"
           >
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              {sidebarCollapsed ? (
+              {isMobile ? (
+                <polyline points="3 6 9 12 3 18" />
+              ) : sidebarCollapsed ? (
                 <polyline points="9 18 15 12 9 6" />
               ) : (
                 <polyline points="15 18 9 12 15 6" />

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -94,10 +94,30 @@
     width: 100%;
     overflow: hidden;
     overscroll-behavior: none;
-    touch-action: none;
+    touch-action: manipulation;
     position: fixed;
     inset: 0;
   }
+}
+
+/* Preserve touch-action: none only on terminal containers */
+.terminal-container {
+  touch-action: none;
+}
+
+/* Sidebar mobile slide animation */
+@keyframes slideInFromLeft {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(0); }
+}
+
+.sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
+  animation: fadeIn 0.2s ease-out;
 }
 
 /* Scrollbar styling */


### PR DESCRIPTION
## Problem

The web dashboard has several mobile usability issues:
- Sidebar takes 60%+ of screen width on phones
- StatusBar and TopBar overflow on small screens
- Grid layouts have fixed minimum widths that exceed mobile viewport
- touch-action: none on body blocks native scroll in Overview/Settings
- user-scalable=no prevents accessibility zoom

## Changes

### Layout
- **Sidebar**: drawer overlay on mobile (<768px) with backdrop tap-to-close and slide-in animation
- **StatusBar**: hide non-critical stats (PEERS, HOSTS, CPU, MEM, PUSH, version) on small screens
- **Overview**: fluid grids using min(min(320px,100%),1fr) so cards fit any viewport

### Touch and Accessibility
- CSS: touch-action: manipulation instead of none on body
- Dedicated .terminal-container class with touch-action: none for xterm areas only
- Viewport: user-scalable=yes, maximum-scale=5.0 for accessibility

### Settings
- Rows stack vertically on mobile (label above control)

## Files Changed
- web/src/App.tsx - useIsMobile hook, mobile sidebar state
- web/src/components/Sidebar.tsx - mobile drawer overlay
- web/src/components/TopBar.tsx - mobile-aware toggle
- web/src/components/StatusBar.tsx - responsive stat visibility
- web/src/components/Overview.tsx - fluid grids
- web/src/components/Settings.tsx - stacked rows on mobile
- web/src/index.css - touch-action, slide animation
- web/index.html - viewport accessibility
