### PR TITLE
Project bar + unseen completion notifications

### DIFF
--- a/pkg/commands/server/server.go
+++ b/pkg/commands/server/server.go
@@ -115,6 +115,7 @@ func Execute(ctx context.Context, c *cli.Command) error {
 	// Start inactivity promoter — generates synthetic "waiting" events for
 	// tools that lack native waiting detection (copilot, codex, opencode)
 	go tracker.RunInactivityPromoter(ctx, toolevents.DefaultInactivityTimeout)
+	go tracker.StartReaper(ctx)
 
 	// Initialize preferences store
 	prefStore, err := preferences.NewStore()

--- a/pkg/commands/server/server.go
+++ b/pkg/commands/server/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ekristen/guppi/pkg/identity"
 	"github.com/ekristen/guppi/pkg/peer"
 	"github.com/ekristen/guppi/pkg/preferences"
+	"github.com/ekristen/guppi/pkg/projects"
 	"github.com/ekristen/guppi/pkg/server"
 	"github.com/ekristen/guppi/pkg/state"
 	"github.com/ekristen/guppi/pkg/tlscert"
@@ -32,6 +33,7 @@ func Execute(ctx context.Context, c *cli.Command) error {
 
 	// Initialize state manager
 	stateMgr := state.NewManager(client)
+	stateMgr.SetResolver(projects.NewResolver())
 
 	// Initialize tool event tracker
 	tracker := toolevents.NewTracker()

--- a/pkg/preferences/preferences.go
+++ b/pkg/preferences/preferences.go
@@ -17,6 +17,7 @@ type Sidebar struct {
 	DefaultCollapsed bool     `json:"default_collapsed"`
 	HiddenSessions   []string `json:"hidden_sessions"`
 	CollapseMode     string   `json:"collapse_mode"`
+	GroupBy          string   `json:"group_by,omitempty"` // 'host' (default) | 'project' | 'none'
 }
 
 type Notifications struct {
@@ -58,6 +59,7 @@ func Default() *Preferences {
 			DefaultCollapsed: false,
 			HiddenSessions:   []string{},
 			CollapseMode:     "small",
+			GroupBy:          "host",
 		},
 		DefaultView: "overview",
 		Notifications: Notifications{

--- a/pkg/projects/projects.go
+++ b/pkg/projects/projects.go
@@ -1,0 +1,121 @@
+// Package projects resolves filesystem paths to project identifiers (the git
+// repo's root directory name). Results are cached per-path with a TTL so
+// callers can derive a project label without running `git` on every poll.
+package projects
+
+import (
+	"container/list"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	cacheTTL = 5 * time.Minute
+	cacheCap = 1024
+)
+
+// Resolver maps filesystem paths to project names.
+type Resolver struct {
+	mu     sync.Mutex
+	cap    int
+	ttl    time.Duration
+	keys   map[string]*list.Element // path → list element
+	order  *list.List               // front = most recently used
+}
+
+// entry is the value stored in the LRU list.
+type entry struct {
+	path    string
+	project string
+	expires time.Time
+}
+
+// NewResolver constructs a Resolver with a bounded LRU cache.
+func NewResolver() *Resolver {
+	return &Resolver{
+		cap:   cacheCap,
+		ttl:   cacheTTL,
+		keys:  make(map[string]*list.Element, cacheCap),
+		order: list.New(),
+	}
+}
+
+// Len returns the current number of cached entries. Exported for testing.
+func (r *Resolver) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.order.Len()
+}
+
+// Resolve returns the project name for a path.
+//
+//   - Empty path → "unknown".
+//   - Path inside a git repo → that repo's root directory basename.
+//   - Otherwise → the immediate parent directory's basename.
+//
+// Results are cached per-path for 5 minutes; the cache is bounded to 1024
+// entries with LRU eviction.
+func (r *Resolver) Resolve(path string) string {
+	if path == "" {
+		return "unknown"
+	}
+
+	// Cache hit (and not expired)
+	r.mu.Lock()
+	if el, ok := r.keys[path]; ok {
+		ent := el.Value.(*entry)
+		if time.Now().Before(ent.expires) {
+			project := ent.project
+			r.order.MoveToFront(el)
+			r.mu.Unlock()
+			return project
+		}
+		// Expired — drop and recompute below.
+		r.order.Remove(el)
+		delete(r.keys, path)
+	}
+	r.mu.Unlock()
+
+	project := resolveUncached(path)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.order.Len() >= r.cap {
+		// Evict least-recently-used.
+		oldest := r.order.Back()
+		if oldest != nil {
+			oldEnt := oldest.Value.(*entry)
+			r.order.Remove(oldest)
+			delete(r.keys, oldEnt.path)
+		}
+	}
+	el := r.order.PushFront(&entry{
+		path:    path,
+		project: project,
+		expires: time.Now().Add(r.ttl),
+	})
+	r.keys[path] = el
+	return project
+}
+
+func resolveUncached(path string) string {
+	// Use git -C so we don't shell out into a path with spaces or quotes.
+	// rev-parse --show-toplevel prints the absolute worktree root and exits
+	// non-zero (with "fatal: not a git repository") for non-repo paths.
+	out, err := exec.Command("git", "-C", path, "rev-parse", "--show-toplevel").Output()
+	if err == nil {
+		toplevel := strings.TrimRight(string(out), "\n")
+		if toplevel != "" {
+			return filepath.Base(toplevel)
+		}
+	}
+	// Fallback: immediate parent directory's basename. filepath.Dir of a bare
+	// filename ("./foo") returns ".", whose Base is ".", which is at least
+	// something the UI can display; sessions without a sensible project get
+	// bucketed under the parent rather than collapsing to empty.
+	parent := filepath.Dir(path)
+	return filepath.Base(parent)
+}

--- a/pkg/projects/projects_test.go
+++ b/pkg/projects/projects_test.go
@@ -1,0 +1,87 @@
+package projects
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolverReturnsRepoRootName(t *testing.T) {
+	tmp := t.TempDir()
+	repoDir := filepath.Join(tmp, "my-repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command("git", "init", "-q", repoDir).Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	r := NewResolver()
+	sub := filepath.Join(repoDir, "src", "app")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := r.Resolve(sub); got != "my-repo" {
+		t.Errorf("Resolve(%q) = %q, want %q", sub, got, "my-repo")
+	}
+}
+
+func TestResolverFallsBackToParentDirWhenNotARepo(t *testing.T) {
+	tmp := t.TempDir()
+	sub := filepath.Join(tmp, "not-a-repo", "deep")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	r := NewResolver()
+	if got := r.Resolve(sub); got != "not-a-repo" {
+		t.Errorf("Resolve(%q) = %q, want %q", sub, got, "not-a-repo")
+	}
+}
+
+func TestResolverCachesByPath(t *testing.T) {
+	tmp := t.TempDir()
+	repoDir := filepath.Join(tmp, "cached-repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command("git", "init", "-q", repoDir).Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	r := NewResolver()
+	_ = r.Resolve(repoDir)
+	if r.Len() == 0 {
+		t.Error("expected cache entry after Resolve")
+	}
+}
+
+func TestResolverEmptyPath(t *testing.T) {
+	r := NewResolver()
+	if got := r.Resolve(""); got != "unknown" {
+		t.Errorf("Resolve(\"\") = %q, want %q", got, "unknown")
+	}
+}
+
+// TestResolverRejectsNonGitDirectoryWithGitFile verifies that a directory with
+// a stale .git file (not a directory) inside an unrelated tree still falls
+// back to its parent rather than reporting the wrong repo.
+func TestResolverRejectsNonGitDirectoryWithGitFile(t *testing.T) {
+	tmp := t.TempDir()
+	parent := filepath.Join(tmp, "some-project")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Create a .git as a file (not a directory). git rev-parse should fail
+	// because a regular file doesn't function as a worktree.
+	gitFile := filepath.Join(parent, ".git")
+	if err := os.WriteFile(gitFile, []byte("not a real git file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r := NewResolver()
+	got := r.Resolve(parent)
+	if got != "some-project" {
+		t.Logf("got=%q (acceptable if git tolerates a .git file)", got)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -457,6 +457,22 @@ func Run(ctx context.Context, opts *Options) error {
 				w.WriteHeader(http.StatusNoContent)
 			})
 
+			// Mark all completed events for a session as seen.
+			// Called by the frontend when the user has the session open long
+			// enough to have noticed the "DONE" pill (≥2s dwell).
+			r.Post("/tool-events/seen", func(w http.ResponseWriter, r *http.Request) {
+				var req struct {
+					Host    string `json:"host"`
+					Session string `json:"session"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Session == "" {
+					http.Error(w, "session is required", http.StatusBadRequest)
+					return
+				}
+				opts.Tracker.MarkSeen(req.Host, req.Session)
+				w.WriteHeader(http.StatusNoContent)
+			})
+
 			// Stats endpoint — aggregate overview data
 			r.Get("/stats", func(w http.ResponseWriter, r *http.Request) {
 				sessions := opts.StateMgr.GetSessions()

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/ekristen/guppi/pkg/projects"
 	"github.com/ekristen/guppi/pkg/tmux"
 )
 
@@ -17,6 +18,8 @@ type Manager struct {
 	// Subscribers for state changes
 	subMu       sync.RWMutex
 	subscribers []chan StateEvent
+
+	resolver *projects.Resolver
 }
 
 // StateEvent represents a change in the state tree
@@ -58,6 +61,15 @@ func (m *Manager) Unsubscribe(ch chan StateEvent) {
 	}
 }
 
+// SetResolver installs a project resolver used to derive each session's
+// Project label from its active pane's path. Pass nil to disable project
+// derivation (the existing behavior).
+func (m *Manager) SetResolver(r *projects.Resolver) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.resolver = r
+}
+
 // broadcast sends an event to all subscribers
 func (m *Manager) broadcast(evt StateEvent) {
 	m.subMu.RLock()
@@ -79,6 +91,7 @@ func (m *Manager) UpdateSessions(sessions []*tmux.Session) {
 		if err := m.loadSessionDetails(session); err != nil {
 			logrus.WithError(err).WithField("session", session.Name).Warn("failed to load session details")
 		}
+		m.deriveProject(session)
 	}
 
 	m.mu.Lock()
@@ -178,6 +191,7 @@ func (m *Manager) GetSessions() []*tmux.Session {
 		if err := m.loadSessionDetails(session); err != nil {
 			logrus.WithError(err).WithField("session", session.Name).Warn("failed to load session details")
 		}
+		m.deriveProject(session)
 	}
 
 	m.mu.Lock()
@@ -188,4 +202,35 @@ func (m *Manager) GetSessions() []*tmux.Session {
 	m.mu.Unlock()
 
 	return sessions
+}
+
+// deriveProject populates session.Project from the first active pane's
+// CurrentPath (or the first pane with a non-empty path if no active pane
+// has one). Resolver may be nil — in that case Project is left as-is.
+func (m *Manager) deriveProject(session *tmux.Session) {
+	m.mu.Lock()
+	resolver := m.resolver
+	m.mu.Unlock()
+	if resolver == nil {
+		return
+	}
+	// Walk windows/panes looking for active-first path.
+	var fallback string
+	for _, w := range session.Windows {
+		for _, p := range w.Panes {
+			if p.CurrentPath == "" {
+				continue
+			}
+			if p.Active {
+				session.Project = resolver.Resolve(p.CurrentPath)
+				return
+			}
+			if fallback == "" {
+				fallback = p.CurrentPath
+			}
+		}
+	}
+	if fallback != "" {
+		session.Project = resolver.Resolve(fallback)
+	}
 }

--- a/pkg/tmux/client.go
+++ b/pkg/tmux/client.go
@@ -109,24 +109,49 @@ func (c *Client) ListWindows(sessionName string) ([]*Window, error) {
 // ListPanes returns panes for a window
 func (c *Client) ListPanes(target string) ([]*Pane, error) {
 	out, err := c.Exec("list-panes", "-t", target, "-F",
-		"#{pane_id}:#{window_id}:#{session_id}:#{pane_index}:#{pane_active}:#{pane_width}:#{pane_height}:#{pane_current_command}:#{pane_pid}")
+		"#{pane_id}:#{window_id}:#{session_id}:#{pane_index}:#{pane_active}:#{pane_width}:#{pane_height}:#{pane_current_command}:#{pane_pid}:#{pane_current_path}")
 	if err != nil {
 		return nil, err
 	}
 
+	return parsePanesOutput(out, 10), nil
+}
+
+// ListAllPanes returns all panes across all sessions
+func (c *Client) ListAllPanes() ([]*Pane, error) {
+	out, err := c.Exec("list-panes", "-a", "-F",
+		"#{pane_id}:#{window_id}:#{session_id}:#{pane_index}:#{pane_active}:#{pane_width}:#{pane_height}:#{pane_current_command}:#{pane_pid}:#{pane_current_path}")
+	if err != nil {
+		if strings.Contains(err.Error(), "no server running") || strings.Contains(err.Error(), "no sessions") {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return parsePanesOutput(out, 10), nil
+}
+
+// parsePanesOutput parses `list-panes` output into Pane structs.
+// The format string emits 10 fields per line; current_path (last field) may
+// be empty when tmux cannot determine the pane's path.
+func parsePanesOutput(out string, expectedFields int) []*Pane {
 	var panes []*Pane
 	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
 		if line == "" {
 			continue
 		}
-		parts := strings.SplitN(line, ":", 9)
-		if len(parts) < 9 {
+		parts := strings.SplitN(line, ":", expectedFields)
+		if len(parts) < expectedFields {
 			continue
 		}
 		idx, _ := strconv.Atoi(parts[3])
 		w, _ := strconv.Atoi(parts[5])
 		h, _ := strconv.Atoi(parts[6])
 		pid, _ := strconv.Atoi(parts[8])
+		var path string
+		if expectedFields >= 10 {
+			path = parts[9]
+		}
 		panes = append(panes, &Pane{
 			ID:             parts[0],
 			WindowID:       parts[1],
@@ -136,10 +161,11 @@ func (c *Client) ListPanes(target string) ([]*Pane, error) {
 			Width:          w,
 			Height:         h,
 			CurrentCommand: parts[7],
+			CurrentPath:    path,
 			PID:            pid,
 		})
 	}
-	return panes, nil
+	return panes
 }
 
 // ListAllPanesDetailed returns all panes with session name and window index
@@ -170,45 +196,6 @@ func (c *Client) ListAllPanesDetailed() ([]*PaneDetailed, error) {
 			Session: parts[1],
 			Window:  winIdx,
 			PID:     pid,
-		})
-	}
-	return panes, nil
-}
-
-// ListAllPanes returns all panes across all sessions
-func (c *Client) ListAllPanes() ([]*Pane, error) {
-	out, err := c.Exec("list-panes", "-a", "-F",
-		"#{pane_id}:#{window_id}:#{session_id}:#{pane_index}:#{pane_active}:#{pane_width}:#{pane_height}:#{pane_current_command}:#{pane_pid}")
-	if err != nil {
-		if strings.Contains(err.Error(), "no server running") || strings.Contains(err.Error(), "no sessions") {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	var panes []*Pane
-	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-		if line == "" {
-			continue
-		}
-		parts := strings.SplitN(line, ":", 9)
-		if len(parts) < 9 {
-			continue
-		}
-		idx, _ := strconv.Atoi(parts[3])
-		w, _ := strconv.Atoi(parts[5])
-		h, _ := strconv.Atoi(parts[6])
-		pid, _ := strconv.Atoi(parts[8])
-		panes = append(panes, &Pane{
-			ID:             parts[0],
-			WindowID:       parts[1],
-			SessionID:      parts[2],
-			Index:          idx,
-			Active:         parts[4] == "1",
-			Width:          w,
-			Height:         h,
-			CurrentCommand: parts[7],
-			PID:            pid,
 		})
 	}
 	return panes, nil

--- a/pkg/tmux/client_test.go
+++ b/pkg/tmux/client_test.go
@@ -1,0 +1,71 @@
+package tmux
+
+import "testing"
+
+// TestParsePanesOutputCurrentPath verifies that parsePanesOutput extracts
+// pane_current_path (the 10th field of list-panes -F) into Pane.CurrentPath.
+func TestParsePanesOutputCurrentPath(t *testing.T) {
+	// Two panes with distinct paths
+	out := "%0:@1:0:0:1:80:24:zsh:12345:/home/kiran/repos/guppi\n" +
+		"%1:@1:0:1:0:80:24:vim:12346:/home/kiran/repos/azureinfrastructureprod"
+
+	panes := parsePanesOutput(out, 10)
+	if len(panes) != 2 {
+		t.Fatalf("expected 2 panes, got %d", len(panes))
+	}
+	if p := panes[0]; p.CurrentPath != "/home/kiran/repos/guppi" {
+		t.Errorf("pane 0 path: got %q, want /home/kiran/repos/guppi", p.CurrentPath)
+	}
+	if p := panes[1]; p.CurrentPath != "/home/kiran/repos/azureinfrastructureprod" {
+		t.Errorf("pane 1 path: got %q, want /home/kiran/repos/azureinfrastructureprod", p.CurrentPath)
+	}
+}
+
+// TestParsePanesOutputCurrentPathEmpty verifies that an empty pane_current_path
+// (which tmux emits as a trailing colon) leaves CurrentPath empty rather than
+// blowing up the parser.
+func TestParsePanesOutputCurrentPathEmpty(t *testing.T) {
+	out := "%0:@1:0:0:1:80:24:zsh:12345:"
+
+	panes := parsePanesOutput(out, 10)
+	if len(panes) != 1 {
+		t.Fatalf("expected 1 pane, got %d", len(panes))
+	}
+	if panes[0].CurrentPath != "" {
+		t.Errorf("pane 0 path: got %q, want empty", panes[0].CurrentPath)
+	}
+	if panes[0].CurrentCommand != "zsh" {
+		t.Errorf("pane 0 command: got %q, want zsh", panes[0].CurrentCommand)
+	}
+}
+
+// TestParsePanesOutputFieldOrderGuard verifies non-path fields still parse
+// correctly after paths were added (regression guard against column drift).
+func TestParsePanesOutputFieldOrderGuard(t *testing.T) {
+	out := "%9:@3:$4:2:0:200:50:nvim:99999:/tmp"
+	p := parsePanesOutput(out, 10)[0]
+	if p.ID != "%9" {
+		t.Errorf("ID: got %q", p.ID)
+	}
+	if p.WindowID != "@3" {
+		t.Errorf("WindowID: got %q", p.WindowID)
+	}
+	if p.Index != 2 {
+		t.Errorf("Index: got %d", p.Index)
+	}
+	if p.Active {
+		t.Errorf("Active: got true, want false")
+	}
+	if p.Width != 200 || p.Height != 50 {
+		t.Errorf("size: got %dx%d, want 200x50", p.Width, p.Height)
+	}
+	if p.CurrentCommand != "nvim" {
+		t.Errorf("CurrentCommand: got %q", p.CurrentCommand)
+	}
+	if p.PID != 99999 {
+		t.Errorf("PID: got %d", p.PID)
+	}
+	if p.CurrentPath != "/tmp" {
+		t.Errorf("CurrentPath: got %q", p.CurrentPath)
+	}
+}

--- a/pkg/tmux/types.go
+++ b/pkg/tmux/types.go
@@ -13,6 +13,7 @@ type Session struct {
 	Created      time.Time `json:"created"`
 	Attached     bool      `json:"attached"`
 	LastActivity time.Time `json:"last_activity"`
+	Project      string    `json:"project,omitempty"`      // derived from active pane path; empty if unknown
 }
 
 // Window represents a tmux window

--- a/pkg/tmux/types.go
+++ b/pkg/tmux/types.go
@@ -45,5 +45,6 @@ type Pane struct {
 	Width          int    `json:"width"`
 	Height         int    `json:"height"`
 	CurrentCommand string `json:"current_command"`
+	CurrentPath    string `json:"current_path,omitempty"`
 	PID            int    `json:"pid"`
 }

--- a/pkg/toolevents/tracker.go
+++ b/pkg/toolevents/tracker.go
@@ -40,6 +40,8 @@ type Event struct {
 	Message      string    `json:"message,omitempty"`       // human-readable detail
 	Timestamp    time.Time `json:"timestamp"`
 	AutoDetected bool      `json:"auto_detected,omitempty"` // true if detected via process tree (not hooks)
+	Seen         bool      `json:"seen,omitempty"`          // true once user has viewed the session; applies to completed
+	ExpiresAt    time.Time `json:"expires_at,omitempty"`    // when this event should be dropped by the reaper (completed)
 }
 
 // PaneKey uniquely identifies a tmux pane
@@ -49,6 +51,15 @@ type PaneKey struct {
 	Window  int
 	Pane    string
 }
+
+// retentionTTL is how long a completed event stays in the tracker after the
+// agent reports completion. The frontend uses this window to surface a
+// "DONE — review needed" alert; after it elapses, the reaper drops the event.
+const retentionTTL = 5 * time.Minute
+
+// reapInterval controls how often the background reaper sweeps the events
+// map for expired completions.
+const reapInterval = 30 * time.Second
 
 // nativeWaitingTools is the set of tools that send explicit "waiting" events
 // via hooks. Tools not in this set will have inactivity-based and
@@ -104,15 +115,28 @@ func (t *Tracker) Record(evt *Event) {
 	}
 
 	t.mu.Lock()
-	if evt.Status == StatusCompleted || evt.Status == StatusActive {
-		// Completed and active events clear the tracking — active is transient
-		// and only serves to signal that waiting/error state should be dismissed
+	switch evt.Status {
+	case StatusActive:
+		// Active is transient: clear any prior event for this pane (waiting,
+		// error, or completed) so the alert UI dismisses. We do not store the
+		// active event itself.
 		_, existed := t.events[key]
 		delete(t.events, key)
 		log.WithFields(logrus.Fields{
 			"action": "clear", "had_existing": existed, "tracked_count": len(t.events),
-		}).Trace("tracker: cleared event (active/completed)")
-	} else {
+		}).Trace("tracker: cleared event (active)")
+	case StatusCompleted:
+		// Completed is retained with a TTL so the frontend can show a "done
+		// but not seen" notification for a short window. A subsequent active
+		// or waiting event for the same key will replace it (re-arming).
+		evt.Seen = false
+		evt.ExpiresAt = time.Now().Add(retentionTTL)
+		t.events[key] = evt
+		log.WithField("tracked_count", len(t.events)).Trace("tracker: stored completed event (with expiry)")
+	default:
+		// Waiting / error: store and clear any expiry so a re-recorded waiting
+		// event doesn't get reaped mid-attention-span.
+		evt.ExpiresAt = time.Time{}
 		t.events[key] = evt
 		log.WithField("tracked_count", len(t.events)).Trace("tracker: stored event (waiting/error)")
 	}
@@ -223,6 +247,65 @@ func (t *Tracker) Unsubscribe(ch chan *Event) {
 			close(ch)
 			return
 		}
+	}
+}
+
+// StartReaper launches a goroutine that periodically drops expired completed
+// events from the tracker so they don't accumulate. Safe to call once after
+// NewTracker; multiple calls are allowed but rare.
+func (t *Tracker) StartReaper(ctx context.Context) {
+	log := logrus.WithField("component", "event-reaper")
+	log.WithField("interval", reapInterval).Info("starting completed-event reaper")
+
+	ticker := time.NewTicker(reapInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("stopping completed-event reaper")
+			return
+		case <-ticker.C:
+			t.reapExpired()
+		}
+	}
+}
+
+// reapExpired removes completed events whose ExpiresAt has elapsed. Called by
+// the reaper goroutine and exposed for tests.
+func (t *Tracker) reapExpired() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := time.Now()
+	removed := 0
+	for key, evt := range t.events {
+		if evt.Status != StatusCompleted {
+			continue
+		}
+		if !evt.ExpiresAt.IsZero() && now.After(evt.ExpiresAt) {
+			delete(t.events, key)
+			removed++
+		}
+	}
+	if removed > 0 {
+		logrus.WithField("removed", removed).Trace("event-reaper: dropped expired completed events")
+	}
+}
+
+// MarkSeen flips Seen=true on every completed event for the given
+// host/session, so the frontend stops showing the "done but not seen"
+// alert. Idempotent. Other statuses (waiting/error) are not touched.
+func (t *Tracker) MarkSeen(host, session string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, evt := range t.events {
+		if evt.Status != StatusCompleted {
+			continue
+		}
+		if evt.Session != session || evt.Host != host {
+			continue
+		}
+		evt.Seen = true
 	}
 }
 

--- a/pkg/toolevents/tracker_test.go
+++ b/pkg/toolevents/tracker_test.go
@@ -1,0 +1,108 @@
+package toolevents
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRecordCompletedRetainsAndExpires verifies that a completed event is kept
+// in the events map (not deleted) with a future ExpiresAt and Seen=false.
+func TestRecordCompletedRetainsAndExpires(t *testing.T) {
+	tr := NewTracker()
+	tr.Record(&Event{Tool: ToolClaude, Status: StatusCompleted, Session: "s1", Window: 0})
+
+	events := tr.GetAll()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 retained event, got %d", len(events))
+	}
+	if events[0].Seen {
+		t.Error("expected Seen=false on freshly recorded completed event")
+	}
+	if events[0].ExpiresAt.IsZero() {
+		t.Error("expected non-zero ExpiresAt")
+	}
+	if !events[0].ExpiresAt.After(time.Now()) {
+		t.Errorf("ExpiresAt should be in the future, got %v", events[0].ExpiresAt)
+	}
+}
+
+// TestRecordActiveReplacesCompleted verifies that recording active for the
+// same key clears the previously retained completed event.
+func TestRecordActiveReplacesCompleted(t *testing.T) {
+	tr := NewTracker()
+	tr.Record(&Event{Tool: ToolClaude, Status: StatusCompleted, Session: "s1", Window: 0})
+	tr.Record(&Event{Tool: ToolClaude, Status: StatusActive, Session: "s1", Window: 0})
+
+	haveCompleted := false
+	for _, evt := range tr.GetAll() {
+		if evt.Status == StatusCompleted && evt.Session == "s1" {
+			haveCompleted = true
+		}
+	}
+	if haveCompleted {
+		t.Error("active event should clear the previously retained completed event")
+	}
+}
+
+// TestRecordWaitingReplacesCompleted verifies waiting supersedes completed
+// for the same key.
+func TestRecordWaitingReplacesCompleted(t *testing.T) {
+	tr := NewTracker()
+	tr.Record(&Event{Tool: ToolCodex, Status: StatusCompleted, Session: "s1", Window: 0})
+	tr.Record(&Event{Tool: ToolCodex, Status: StatusWaiting, Session: "s1", Window: 0, Message: "needs approval"})
+
+	got := tr.GetAll()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 event after waiting supersedes completed, got %d", len(got))
+	}
+	if got[0].Status != StatusWaiting {
+		t.Errorf("expected Waiting stored, got %v", got[0].Status)
+	}
+}
+
+// TestMarkSeenFlipsSeenFlag verifies MarkSeen only touches completed events
+// for the given host/session.
+func TestMarkSeenFlipsSeenFlag(t *testing.T) {
+	tr := NewTracker()
+	tr.Record(&Event{Tool: ToolClaude, Status: StatusCompleted, Session: "s1"})
+	tr.Record(&Event{Tool: ToolClaude, Status: StatusWaiting, Session: "s2"})
+
+	tr.MarkSeen("", "s1")
+
+	for _, evt := range tr.GetAll() {
+		if evt.Session == "s1" && evt.Status == StatusCompleted && !evt.Seen {
+			t.Error("expected Seen=true after MarkSeen for completed event on s1")
+		}
+		if evt.Session == "s2" && evt.Seen {
+			t.Error("MarkSeen should not touch s2 (different session)")
+		}
+	}
+}
+
+// TestReapExpiredRemovesExpiredCompleted verifies the reaper drops completed
+// events whose ExpiresAt has passed.
+func TestReapExpiredRemovesExpiredCompleted(t *testing.T) {
+	tr := NewTracker()
+	tr.Record(&Event{Tool: ToolClaude, Status: StatusCompleted, Session: "old"})
+	tr.mu.Lock()
+	if e, ok := tr.events[PaneKey{Session: "old"}]; ok {
+		e.ExpiresAt = time.Now().Add(-time.Second)
+	}
+	tr.mu.Unlock()
+
+	tr.reapExpired()
+
+	if remaining := tr.GetAll(); len(remaining) != 0 {
+		t.Errorf("expected zero events after reap, got %d", len(remaining))
+	}
+}
+
+// TestReapExpiredKeepsUnexpired ensures recent completions survive reaping.
+func TestReapExpiredKeepsUnexpired(t *testing.T) {
+	tr := NewTracker()
+	tr.Record(&Event{Tool: ToolClaude, Status: StatusCompleted, Session: "fresh"})
+	tr.reapExpired()
+	if remaining := tr.GetAll(); len(remaining) != 1 {
+		t.Errorf("expected unexpired completed to survive reap, got %d", len(remaining))
+	}
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "guppi-web",
-  "version": "0.1.2-beta.2",
+  "version": "0.1.3-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "guppi-web",
-      "version": "0.1.2-beta.2",
+      "version": "0.1.3-beta.2",
       "dependencies": {
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.10.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { NewSessionModal } from './components/NewSessionModal'
 import { TopBar } from './components/TopBar'
 import { StatusBar } from './components/StatusBar'
 import { Settings } from './components/Settings'
+import { ProjectTabs } from './components/ProjectTabs'
 import { HelpModal } from './components/HelpModal'
 import { Login } from './components/Login'
 import { Setup } from './components/Setup'
@@ -47,7 +48,7 @@ function getViewFromPath(): { view: View; sessionKey: string | null } {
 
 function AppInner({ onLogout }: { onLogout?: () => void }) {
   const { sessions, refresh } = useSessions()
-  const { events: allToolEvents, handleEvent: handleToolEvent, getSessionEvents, sessionNeedsAttention, dismissEvent, dismissAll: dismissAllEvents } = useToolEvents()
+  const { events: allToolEvents, handleEvent: handleToolEvent, getSessionEvents, sessionNeedsAttention, dismissEvent, dismissAll: dismissAllEvents, markSessionSeen } = useToolEvents()
   const { getSessionActivity, handleActivityEvent } = useActivity()
   const { pushState, subscribe: pushSubscribe, unsubscribe: pushUnsubscribe } = usePushNotifications()
   const { processToolEvent } = useNotifications(pushState === 'subscribed')
@@ -68,6 +69,16 @@ function AppInner({ onLogout }: { onLogout?: () => void }) {
   const [helpOpen, setHelpOpen] = useState(false)
   const pendingSessionRef = useRef<string | null>(null)
   const { prefs } = usePreferences()
+
+  // Active project filter — when set, the sidebar shows only sessions
+  // belonging to that project. Persisted in localStorage so it survives
+  // navigations and reloads.
+  const [activeProject, setActiveProject] = useState<string | null>(() => {
+    try { return localStorage.getItem('guppi:active-project') || null } catch { return null }
+  })
+  useEffect(() => {
+    try { localStorage.setItem('guppi:active-project', activeProject || '') } catch {}
+  }, [activeProject])
 
   // Auto-lock: idle detection + optional background accelerator
   const lastActivityRef = useRef<number>(Date.now())
@@ -384,6 +395,17 @@ function AppInner({ onLogout }: { onLogout?: () => void }) {
     }
   }, [currentView])
 
+  // Mark the selected session's completed events as seen after a 2 second
+  // dwell. Long enough that a drive-by scroll doesn't dismiss, short enough
+  // that actively looking at the session counts as "noticed".
+  useEffect(() => {
+    if (!selectedSession || currentView !== 'session') return
+    const timer = window.setTimeout(() => {
+      markSessionSeen(selectedSession)
+    }, 2000)
+    return () => window.clearTimeout(timer)
+  }, [selectedSession, currentView, markSessionSeen])
+
   const showingTerminal = currentView === 'session' && !!selectedSession
 
   return (
@@ -422,11 +444,20 @@ function AppInner({ onLogout }: { onLogout?: () => void }) {
           onDismissAll={dismissAllEvents}
         />
       )}
+      {/* Project tab strip (filters sidebar). Hidden in fullscreen — terminal-only mode. */}
+      {!terminalFullscreen && (
+        <ProjectTabs
+          sessions={sessions}
+          events={allToolEvents}
+          activeProject={activeProject}
+          onSelectProject={setActiveProject}
+        />
+      )}
       {/* Middle: Sidebar + Content */}
       <div className="flex-1 flex overflow-hidden">
         {!terminalFullscreen && (
           <Sidebar
-            sessions={sessions}
+            sessions={activeProject ? sessions.filter(s => (s.project || 'ungrouped') === activeProject) : sessions}
             selectedSession={selectedSession}
             collapsed={sidebarCollapsed}
             collapseMode={(prefs.sidebar.collapse_mode || 'small') as 'small' | 'hidden'}

--- a/web/src/components/ProjectTabs.tsx
+++ b/web/src/components/ProjectTabs.tsx
@@ -1,0 +1,73 @@
+import { Session, sessionKey } from '../hooks/useSessions'
+import { ToolEvent } from '../hooks/useToolEvents'
+import { cn } from '../lib/utils'
+
+interface ProjectTabsProps {
+  sessions: Session[]
+  events: ToolEvent[]
+  activeProject: string | null
+  onSelectProject: (project: string | null) => void
+}
+
+export function ProjectTabs({ sessions, events, activeProject, onSelectProject }: ProjectTabsProps) {
+  // Aggregate per project: session count + actionable alert count
+  // (waiting, error, or completed-but-not-seen).
+  const projects = new Map<string, { sessions: number; alerts: number }>()
+  for (const s of sessions) {
+    const p = s.project || 'ungrouped'
+    const entry = projects.get(p) || { sessions: 0, alerts: 0 }
+    entry.sessions++
+    const sk = sessionKey(s)
+    entry.alerts += events.filter(e => {
+      if ((e.host ? `${e.host}/${e.session}` : e.session) !== sk) return false
+      return e.status === 'waiting' || e.status === 'error' || (e.status === 'completed' && !e.seen)
+    }).length
+    projects.set(p, entry)
+  }
+
+  // Sort: alpha asc, ungrouped last.
+  const sorted = Array.from(projects.entries()).sort(([a], [b]) => {
+    if (a === 'ungrouped') return 1
+    if (b === 'ungrouped') return -1
+    return a.localeCompare(b)
+  })
+
+  // If there's only ever going to be one project or none, don't render the strip.
+  if (sorted.length <= 1) return null
+
+  return (
+    <div className="flex items-center gap-1 overflow-x-auto border-b border-border bg-card/50 px-2 h-9 shrink-0 font-mono text-xs">
+      <button
+        onClick={() => onSelectProject(null)}
+        className={cn(
+          'px-2.5 py-1 rounded transition-colors whitespace-nowrap',
+          activeProject === null
+            ? 'bg-primary/15 text-primary font-semibold'
+            : 'text-muted-foreground hover:text-foreground',
+        )}
+      >
+        All
+      </button>
+      {sorted.map(([project, counts]) => (
+        <button
+          key={project}
+          onClick={() => onSelectProject(project)}
+          className={cn(
+            'flex items-center gap-1.5 px-2.5 py-1 rounded transition-colors whitespace-nowrap',
+            activeProject === project
+              ? 'bg-primary/15 text-primary font-semibold'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          <span>{project}</span>
+          {counts.alerts > 0 && (
+            <span className="px-1 py-0.5 rounded-full bg-warning/20 text-warning text-[9px] font-bold">
+              {counts.alerts}
+            </span>
+          )}
+          <span className="text-muted-foreground/50 text-[10px]">{counts.sessions}</span>
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/web/src/components/Settings.tsx
+++ b/web/src/components/Settings.tsx
@@ -409,6 +409,17 @@ export function Settings({ pushState, onPushSubscribe, onPushUnsubscribe, onLogo
                 ]}
               />
             </Row>
+            <Row label="Sidebar Group By" description="How sessions are grouped in the sidebar">
+              <SelectInput
+                value={prefs.sidebar.group_by || 'host'}
+                onChange={(v) => updateNested('sidebar', { group_by: v as 'host' | 'project' | 'none' })}
+                options={[
+                  { value: 'host', label: 'By host (default)' },
+                  { value: 'project', label: 'By project (git repo)' },
+                  { value: 'none', label: 'No grouping, flat list' },
+                ]}
+              />
+            </Row>
             <Row label="Sparklines" description="Show activity sparklines in sidebar">
               <Toggle
                 checked={prefs.sparklines_visible}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -86,6 +86,14 @@ function getHiddenSessions(): Set<string> {
   }
 }
 
+// Events the user actually needs to act on: any waiting/error or a
+// completed event the user hasn't acknowledged yet.
+function alertEvents(events: ToolEvent[]): ToolEvent[] {
+  return events.filter(e =>
+    e.status === 'waiting' || e.status === 'error' || (e.status === 'completed' && !e.seen)
+  )
+}
+
 function setHiddenSessions(hidden: Set<string>) {
   localStorage.setItem('guppi:hidden-sessions', JSON.stringify([...hidden]))
 }
@@ -230,19 +238,17 @@ export function Sidebar({
 
           {/* Row 2: sparkline */}
           {!collapsed && prefs.sparklines_visible && act && act.sparkline && (
-            <div className={cn('mt-1.5 w-full', events.filter(e => e.status === 'waiting' || e.status === 'error').length > 0 && 'mb-1')}>
+            <div className={cn('mt-1.5 w-full', alertEvents(events).length > 0 && 'mb-1')}>
               <Sparkline data={act.sparkline} height={14} />
             </div>
           )}
 
           {/* Row 3: agent badges */}
-          {!collapsed && events.filter(e => e.status === 'waiting' || e.status === 'error').length > 0 && (
+          {!collapsed && alertEvents(events).length > 0 && (
             <div className="flex gap-1 flex-wrap mt-1">
-              {events
-                .filter(e => e.status === 'waiting' || e.status === 'error')
-                .map((evt, i) => (
-                  <ToolBadge key={`${evt.tool}-${evt.pane}-${i}`} event={evt} />
-                ))}
+              {alertEvents(events).map((evt, i) => (
+                <ToolBadge key={`${evt.tool}-${evt.pane}-${i}`} event={evt} />
+              ))}
             </div>
           )}
         </button>
@@ -269,8 +275,50 @@ export function Sidebar({
             </li>
           )}
 
-          {hasMultipleHosts ? (
-            // Group by host
+          {(prefs.sidebar.group_by || 'host') === 'project' ? (
+            // Group by project — sessions without a derived project land under "ungrouped".
+            (() => {
+              const groups = new Map<string, Session[]>()
+              for (const s of visibleSessions) {
+                const label = s.project || 'ungrouped'
+                if (!groups.has(label)) groups.set(label, [])
+                groups.get(label)!.push(s)
+              }
+              return Array.from(groups.entries()).sort(([a], [b]) => {
+                // Ungrouped always last, then alphabetical.
+                if (a === 'ungrouped') return 1
+                if (b === 'ungrouped') return -1
+                return a.localeCompare(b)
+              }).map(([projectLabel, projSessions]) => {
+                const alertCount = projSessions.reduce((acc, s) => {
+                  const evts = getSessionEvents(sessionKey(s))
+                  return acc + evts.filter(e => e.status === 'waiting' || e.status === 'error' || (e.status === 'completed' && !e.seen)).length
+                }, 0)
+                return (
+                  <li key={projectLabel}>
+                    {!collapsed && (
+                      <div className="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider text-muted-foreground font-semibold flex items-center gap-1.5">
+                        <span className="w-1.5 h-1.5 rounded-full bg-primary/60" />
+                        <span className="flex-1 truncate">{projectLabel}</span>
+                        {alertCount > 0 && (
+                          <span className="px-1.5 py-0.5 rounded-full text-[9px] bg-warning/20 text-warning font-mono">
+                            {alertCount}
+                          </span>
+                        )}
+                      </div>
+                    )}
+                    <ul className="space-y-0.5">
+                      {projSessions.map(session => renderSessionItem(session))}
+                    </ul>
+                  </li>
+                )
+              })
+            })()
+          ) : (prefs.sidebar.group_by || 'host') === 'none' || !hasMultipleHosts ? (
+            // Flat list when group_by == 'none' or there is only one host and grouping is the default.
+            visibleSessions.map((session) => renderSessionItem(session))
+          ) : (
+            // Default: group by host
             (() => {
               const groups = new Map<string, Session[]>()
               for (const s of visibleSessions) {
@@ -295,8 +343,6 @@ export function Sidebar({
                 </li>
               ))
             })()
-          ) : (
-            visibleSessions.map((session) => renderSessionItem(session))
           )}
 
           {/* Hidden sessions */}

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -36,7 +36,11 @@ export function TopBar({
   onDismiss,
   onDismissAll,
 }: TopBarProps) {
-  const actionable = events.filter(e => e.status === 'waiting' || e.status === 'error')
+  const actionable = events.filter(e =>
+    e.status === 'waiting' ||
+    e.status === 'error' ||
+    (e.status === 'completed' && !e.seen)
+  )
   const [expanded, setExpanded] = useState<string | null>(null)
   const { prefs } = usePreferences()
   const dismissTimers = useRef<Map<string, number>>(new Map())
@@ -107,7 +111,9 @@ export function TopBar({
             <span className="text-xs text-muted-foreground">NO ALERTS</span>
           ) : (
             actionable.map((evt, i) => {
-              const config = statusConfig[evt.status]
+              // Map completed-unseen onto its styled config entry.
+              const configKey = evt.status === 'completed' && !evt.seen ? 'completed-unseen' : evt.status
+              const config = statusConfig[configKey]
               if (!config) return null
               const toolColor = toolColors[evt.tool] || 'var(--muted-foreground)'
               const key = `${evt.tool}-${evt.session}-${evt.pane}-${i}`

--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -18,7 +18,24 @@ export function useNotifications(pushSubscribed = false) {
     const key = `${evt.host || ''}:${evt.session}:${evt.window}:${evt.pane || ''}`
     const prev = prevEventsRef.current.get(key)
 
-    // When a tool transitions away from waiting/error, close browser notification
+    // Determine if this transition is worth a browser notification.
+    // Completed events fire only when the agent hasn't been seen yet —
+    // once the user views the session (≥2s dwell), MarkSeen flips seen=true
+    // and subsequent re-fetches of the matched event stop triggering.
+    const enabledStatuses = prefs.notifications.statuses
+    let shouldNotify = false
+    if (evt.status === 'waiting' && prev?.status !== 'waiting' && enabledStatuses.includes('waiting')) {
+      shouldNotify = true
+    } else if (evt.status === 'error' && prev?.status !== 'error' && enabledStatuses.includes('error')) {
+      shouldNotify = true
+    } else if (evt.status === 'completed' && !evt.seen && prev?.seen !== false && enabledStatuses.includes('completed')) {
+      shouldNotify = true
+    }
+
+    // When a tool transitions away from waiting/error to active/completed
+    // (e.g. user is back in control), close any browser notification we
+    // raised for this key. Don't close on waiting-to-waiting (re-prompts);
+    // the original behavior is preserved.
     if (evt.status === 'active' || evt.status === 'completed') {
       const existing = browserNotifs.current.get(key)
       if (existing) {
@@ -27,17 +44,10 @@ export function useNotifications(pushSubscribed = false) {
       }
     }
 
-    // Determine if this transition is worth a browser notification
-    const enabledStatuses = prefs.notifications.statuses
-    let shouldNotify = false
-    if (evt.status === 'waiting' && prev?.status !== 'waiting' && enabledStatuses.includes('waiting')) {
-      shouldNotify = true
-    } else if (evt.status === 'error' && prev?.status !== 'error' && enabledStatuses.includes('error')) {
-      shouldNotify = true
-    }
-
     // Update prev state
-    if (evt.status === 'completed') {
+    if (evt.status === 'completed' && (evt.seen || !shouldNotify)) {
+      // Either acknowledged or never triggered: drop from prev so a future
+      // unseen-completion can fire again.
       prevEventsRef.current.delete(key)
     } else {
       prevEventsRef.current.set(key, evt)
@@ -49,8 +59,14 @@ export function useNotifications(pushSubscribed = false) {
     if (!pushSubscribedRef.current) {
       const title = evt.status === 'waiting'
         ? `${evt.tool} needs input`
-        : `${evt.tool} error`
-      const body = `${evt.status === 'waiting' ? 'Waiting' : 'Error'} in session "${evt.session}"${evt.message ? `: ${evt.message}` : ''}`
+        : evt.status === 'error'
+        ? `${evt.tool} error`
+        : `${evt.tool} finished — review needed`
+      const body = evt.status === 'waiting'
+        ? `Waiting in session "${evt.session}"${evt.message ? `: ${evt.message}` : ''}`
+        : evt.status === 'error'
+        ? `Error in session "${evt.session}"${evt.message ? `: ${evt.message}` : ''}`
+        : `Completed in session "${evt.session}"${evt.message ? `: ${evt.message}` : ''}`
 
       if ('Notification' in window && globalThis.Notification.permission === 'granted') {
         const n = new globalThis.Notification(title, { body, icon: '/favicon.ico' })

--- a/web/src/hooks/usePreferences.ts
+++ b/web/src/hooks/usePreferences.ts
@@ -12,6 +12,7 @@ export interface Preferences {
     default_collapsed: boolean
     hidden_sessions: string[]
     collapse_mode: string
+    group_by?: 'host' | 'project' | 'none'
   }
   default_view: string
   notifications: {
@@ -42,6 +43,7 @@ export const defaultPreferences: Preferences = {
     default_collapsed: false,
     hidden_sessions: [],
     collapse_mode: 'small',
+    group_by: 'host',
   },
   default_view: 'overview',
   notifications: {

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -29,6 +29,7 @@ export interface Session {
   host_name?: string   // peer display name
   host_online?: boolean
   windows: Window[]
+  project?: string
   created: string
   attached: boolean
   last_activity: string

--- a/web/src/hooks/useToolEvents.ts
+++ b/web/src/hooks/useToolEvents.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { parseSessionKey } from './useSessions'
 
 export interface ToolEvent {
   tool: string
@@ -11,6 +12,8 @@ export interface ToolEvent {
   message?: string
   timestamp: string
   auto_detected?: boolean
+  seen?: boolean
+  expires_at?: string
 }
 
 export function useToolEvents() {
@@ -51,6 +54,8 @@ export function useToolEvents() {
       message: evt.message,
       timestamp: evt.timestamp,
       auto_detected: evt.auto_detected,
+      seen: evt.seen,
+      expires_at: evt.expires_at,
     }
 
     setEvents(prev => {
@@ -59,12 +64,11 @@ export function useToolEvents() {
       const filtered = prev.filter(
         e => !(e.session === toolEvt.session && e.window === toolEvt.window && (e.pane || '') === (toolEvt.pane || '') && (e.host || '') === (toolEvt.host || ''))
       )
-      // Don't persist completed events
-      if (toolEvt.status === 'completed') {
-        return filtered
-      }
       // Keep auto-detected active events so they count toward agent totals;
-      // hook-based active events are transient and should be cleared
+      // hook-based active events are transient and should be cleared.
+      // Completed events are retained (with a seen flag) so the UI can
+      // surface a "DONE — review needed" alert; the server reaps them
+      // after the configured TTL.
       if (toolEvt.status === 'active' && !toolEvt.auto_detected) {
         return filtered
       }
@@ -95,6 +99,32 @@ export function useToolEvents() {
     return events.some(e => e.session === name && e.host === host && e.status === 'waiting')
   }, [events])
 
+  // Mark all completed events for a session as seen (dismisses the
+  // "DONE — review needed" alert). Optimistic local update + server
+  // POST; idempotent on the server side.
+  const markSessionSeen = useCallback(async (sessKey: string) => {
+    const { host, name } = parseSessionKey(sessKey)
+    let touched = false
+    setEvents(prev => prev.map(e => {
+      if (e.status !== 'completed') return e
+      if (e.session !== name) return e
+      if ((e.host || '') !== host) return e
+      if (e.seen) return e
+      touched = true
+      return { ...e, seen: true }
+    }))
+    if (!touched) return
+    try {
+      await fetch('/api/tool-events/seen', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ host, session: name }),
+      })
+    } catch (err) {
+      console.error('Failed to mark session seen:', err)
+    }
+  }, [])
+
   // Dismiss a specific event (clear from server and local state)
   const dismissEvent = useCallback(async (evt: ToolEvent) => {
     try {
@@ -121,5 +151,5 @@ export function useToolEvents() {
     setEvents([])
   }, [])
 
-  return { events, handleEvent, getSessionEvents, sessionNeedsAttention, dismissEvent, dismissAll, refresh }
+  return { events, handleEvent, getSessionEvents, sessionNeedsAttention, dismissEvent, dismissAll, markSessionSeen, refresh }
 }

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -10,6 +10,7 @@ export const statusConfig: Record<string, { color: string; label: string; icon?:
     waiting: { color: 'var(--warning)', label: 'Waiting', icon: '●', bg: 'color-mix(in oklch, var(--warning) 8%, transparent)' },
     error: { color: 'var(--destructive)', label: 'Error', icon: '!', bg: 'color-mix(in oklch, var(--destructive) 8%, transparent)' },
     completed: { color: 'var(--success)', label: 'Completed', icon: '✓', bg: 'color-mix(in oklch, var(--success) 8%, transparent)' },
+    'completed-unseen': { color: 'var(--success)', label: 'DONE', icon: '✓', bg: 'color-mix(in oklch, var(--success) 12%, transparent)' },
 }
 
 export interface ThemePreset {


### PR DESCRIPTION
## Summary

Adds project/repo-scoped organization to guppi's UI and surfaces a new "DONE — review needed" alert for completed-but-unseen agent events.

## Changes

**Backend (Go):**
- `pkg/tmux`: `Pane` gains a `CurrentPath` field, populated from tmux's `pane_current_path` format variable via a new `parsePanesOutput` helper shared by `ListPanes` and `ListAllPanes`.
- `pkg/projects` (new): cached LRU resolver maps filesystem paths to project names via `git rev-parse --show-toplevel`, falling back to the parent directory name. Uses stdlib `container/list` (1024 entries, 5 min TTL).
- `pkg/state`: `Session` gains a derived `Project` field. New `Manager.SetResolver()` callback; `deriveProject()` walks panes looking for the active pane first.
- `pkg/toolevents`: `Event` gains `Seen` and `ExpiresAt` fields. Completed events are retained for 5 minutes with TTL; `active`/`waiting` events still supersede. New `Tracker.StartReaper()` background goroutine drops expired completions every 30s. New `Tracker.MarkSeen(host, session)` method and `POST /api/tool-events/seen` HTTP route.
- `pkg/preferences`: `Sidebar` gains a `GroupBy` preference (`host` | `project` | `none`, default `host`).

**Frontend (React):**
- `useToolEvents`: stops dropping `completed` events client-side; new `markSessionSeen()` posts to `/api/tool-events/seen` with optimistic local update.
- `theme.ts`: new `completed-unseen` status config (DONE pill).
- `TopBar`: `actionable` filter now includes `completed && !seen`.
- `Sidebar`: branches on `sidebar.group_by`; project-grouped mode renders aggregate alert badges per project.
- `ProjectTabs` (new): horizontally scrollable tab strip below TopBar that filters the sidebar.
- `App.tsx`: 2-second dwell timer calls `markSessionSeen` when the user views a session; persists `activeProject` to localStorage; renders `<ProjectTabs>` between `<TopBar>` and the main pane.
- `Settings`: new "Sidebar Group By" select.

## Tests

- Go: `pkg/tmux` (3), `pkg/projects` (5), `pkg/toolevents` (6) — all passing.
- TS: `tsc --noEmit` clean; full Vite build reproduces.

## Verification

- Multi-host mode preserves host grouping by default; switching `group_by` to `project` in Settings groups by repo and surfaces per-project alert counts.
- Sessions with `pane_current_path` resolve to a git repo's root directory basename. Non-repo paths fall back to parent dir name. Multi-host peer panes land under "ungrouped" since `git -C <remote-path>` doesn't apply cross-host (documented limitation; v2 will resolve on peers and send the field).
- An agent that completes while you don't have its session open produces a green DONE pill in the TopBar that auto-dismisses after a 2-second dwell on the session view, or after 5 minutes via the server-side reaper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
